### PR TITLE
test:scenarios:tail_null:data_generator: set the default log rate to …

### DIFF
--- a/standalone/test/scenarios/tail_null/scenario_helpers/data_generator/run.sh
+++ b/standalone/test/scenarios/tail_null/scenario_helpers/data_generator/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-INPUT_LOG_RATE=${INPUT_LOG_RATE:-200000}
+INPUT_LOG_RATE=${INPUT_LOG_RATE:-20000}
 INPUT_LOG_SIZE=${INPUT_LOG_SIZE:-1000}
 echo "Starting data generation: $INPUT_LOG_SIZE @ $INPUT_LOG_RATE"
 


### PR DESCRIPTION
…20.000, as per the docs. It is 200.000 currently

Signed-off-by: lecaros <lecaros@calyptia.com>